### PR TITLE
Fix VPK installer foundation and PromoterUtil lifecycle

### DIFF
--- a/Client PSVitaAlive/include/installer/homebrew_installer.hpp
+++ b/Client PSVitaAlive/include/installer/homebrew_installer.hpp
@@ -39,15 +39,18 @@ using InstallProgressFn = std::function<void(const InstallProgress&)>;
 using InstallCancelFn = std::function<bool()>;
 
 /**
- * HomebrewInstaller — Phase 6
+ * HomebrewInstaller — VPK installer.
  *
- * Installs .vpk homebrew packages:
- * 1) Detect format (must be VPK/ZIP)
- * 2) Extract to temp under ux0:data/psvitaalive/tmp/
- * 3) scePromoterUtilityPromotePkg
- * 4) Cleanup temp on success (optional keep on failure)
+ * Installs legitimate PS Vita homebrew VPK packages:
+ * 1) Verify the input is a .vpk ZIP container.
+ * 2) Extract it to a private temporary directory.
+ * 3) Validate the minimum VPK layout (eboot.bin + sce_sys/param.sfo).
+ * 4) Load the Promoter Utility dependencies required by the Vita runtime.
+ * 5) Promote the extracted package directory.
+ * 6) Recursively remove temporary files after a successful install.
  *
- * Does NOT implement DRM bypass. Only legitimate homebrew VPK flow.
+ * This class does NOT implement DRM bypass, license generation, or
+ * installation of encrypted commercial content.
  */
 class HomebrewInstaller {
 public:
@@ -65,8 +68,13 @@ private:
     std::string lastError_;
     int lastPromoteResult_ = 0;
 
+    bool pafLoadedByUs_ = false;
+    bool promoterLoadedByUs_ = false;
+
     void setError(const std::string& msg);
     bool loadPromoterModule();
+    void unloadPromoterModules();
+    bool removeTree(const std::string& path);
     InstallResult promoteExtractedDir(const std::string& dir);
 };
 

--- a/Client PSVitaAlive/source/installer/homebrew_installer.cpp
+++ b/Client PSVitaAlive/source/installer/homebrew_installer.cpp
@@ -18,7 +18,11 @@ namespace psvitaalive {
 
 namespace {
 constexpr const char* TMP_ROOT = "ux0:data/psvitaalive/tmp";
+
+bool isDotEntry(const char* name) {
+    return name && (std::strcmp(name, ".") == 0 || std::strcmp(name, "..") == 0);
 }
+} // namespace
 
 const char* toString(InstallResult r) {
     switch (r) {
@@ -41,41 +45,167 @@ void HomebrewInstaller::setError(const std::string& msg) {
 }
 
 bool HomebrewInstaller::loadPromoterModule() {
-    // SCE_SYSMODULE_PROMOTER_UTIL = 0x0165 typically
-    int r = sceSysmoduleLoadModuleInternal(SCE_SYSMODULE_INTERNAL_PROMOTER_UTIL);
-    if (r < 0) {
-        // Fallback public load if available
-        r = sceSysmoduleLoadModule(static_cast<SceSysmoduleModuleId>(0x165));
+    pafLoadedByUs_ = false;
+    promoterLoadedByUs_ = false;
+
+    // PromoterUtil depends on the internal PAF module on common Vita
+    // homebrew environments. This follows the dependency-loading pattern
+    // used by established Vita homebrew browsers.
+    if (sceSysmoduleIsLoadedInternal(SCE_SYSMODULE_INTERNAL_PAF) < 0) {
+        SceSysmoduleOpt opt;
+        std::memset(&opt, 0, sizeof(opt));
+        opt.result = &opt.flags;
+
+        uint32_t pafArgs[] = {
+            0x400000,
+            0xEA60,
+            0x40000,
+            0,
+            0
+        };
+
+        int r = sceSysmoduleLoadModuleInternalWithArg(
+            SCE_SYSMODULE_INTERNAL_PAF,
+            sizeof(pafArgs),
+            pafArgs,
+            &opt
+        );
+
+        if (r < 0) {
+            char buf[80];
+            sceClibSnprintf(buf, sizeof(buf),
+                            "load PAF failed: 0x%08X", r);
+            setError(buf);
+            return false;
+        }
+
+        pafLoadedByUs_ = true;
     }
-    if (r < 0) {
-        char buf[64];
-        sceClibSnprintf(buf, sizeof(buf), "load promoter failed: 0x%08X", r);
-        setError(buf);
-        return false;
+
+    if (sceSysmoduleIsLoadedInternal(SCE_SYSMODULE_INTERNAL_PROMOTER_UTIL) < 0) {
+        int r = sceSysmoduleLoadModuleInternal(
+            SCE_SYSMODULE_INTERNAL_PROMOTER_UTIL
+        );
+
+        if (r < 0) {
+            char buf[80];
+            sceClibSnprintf(buf, sizeof(buf),
+                            "load promoter failed: 0x%08X", r);
+            setError(buf);
+            unloadPromoterModules();
+            return false;
+        }
+
+        promoterLoadedByUs_ = true;
     }
+
+    sceClibPrintf("[HomebrewInstaller] promoter dependencies loaded\n");
     return true;
 }
 
-InstallResult HomebrewInstaller::promoteExtractedDir(const std::string& dir) {
+void HomebrewInstaller::unloadPromoterModules() {
+    if (promoterLoadedByUs_) {
+        int r = sceSysmoduleUnloadModuleInternal(
+            SCE_SYSMODULE_INTERNAL_PROMOTER_UTIL
+        );
+        if (r < 0) {
+            sceClibPrintf(
+                "[HomebrewInstaller] unload promoter failed: 0x%08X\n",
+                r
+            );
+        }
+        promoterLoadedByUs_ = false;
+    }
+
+    if (pafLoadedByUs_) {
+        int r = sceSysmoduleUnloadModuleInternal(
+            SCE_SYSMODULE_INTERNAL_PAF
+        );
+        if (r < 0) {
+            sceClibPrintf(
+                "[HomebrewInstaller] unload PAF failed: 0x%08X\n",
+                r
+            );
+        }
+        pafLoadedByUs_ = false;
+    }
+}
+
+bool HomebrewInstaller::removeTree(const std::string& path) {
+    StorageManager st;
+
+    if (!st.exists(path)) {
+        return true;
+    }
+
+    if (!st.isDirectory(path)) {
+        return st.removeFile(path);
+    }
+
+    SceUID uid = sceIoDopen(path.c_str());
+    if (uid < 0) {
+        return false;
+    }
+
+    bool ok = true;
+    SceIoDirent ent;
+
+    while (sceIoDread(uid, &ent) > 0) {
+        if (isDotEntry(ent.d_name)) {
+            continue;
+        }
+
+        const std::string child = path + "/" + ent.d_name;
+        const bool childIsDir =
+            (ent.d_stat.st_mode & SCE_S_IFDIR) != 0;
+
+        if (childIsDir) {
+            if (!removeTree(child)) {
+                ok = false;
+                break;
+            }
+        } else if (!st.removeFile(child)) {
+            ok = false;
+            break;
+        }
+    }
+
+    sceIoDclose(uid);
+
+    if (!ok) {
+        return false;
+    }
+
+    return st.removeDirectory(path);
+}
+
+InstallResult HomebrewInstaller::promoteExtractedDir(
+    const std::string& dir
+) {
     int r = scePromoterUtilityInit();
     if (r < 0) {
         char buf[64];
-        sceClibSnprintf(buf, sizeof(buf), "scePromoterUtilityInit: 0x%08X", r);
+        sceClibSnprintf(buf, sizeof(buf),
+                        "scePromoterUtilityInit: 0x%08X", r);
         setError(buf);
         lastPromoteResult_ = r;
         return InstallResult::PromoteFailed;
     }
 
-    // Promote package directory (extracted VPK contents)
+    // PromoterUtil expects the directory containing the extracted package
+    // contents, not the original .vpk file.
     r = scePromoterUtilityPromotePkg(dir.c_str(), 0);
     lastPromoteResult_ = r;
 
-    // Wait until finished
-    int state = 0;
     if (r >= 0) {
+        int state = 0;
+
         do {
             r = scePromoterUtilityGetState(&state);
-            if (r < 0) break;
+            if (r < 0) {
+                break;
+            }
+
             sceKernelDelayThread(100 * 1000);
         } while (state != 0);
 
@@ -88,12 +218,18 @@ InstallResult HomebrewInstaller::promoteExtractedDir(const std::string& dir) {
 
     if (lastPromoteResult_ < 0) {
         char buf[80];
-        sceClibSnprintf(buf, sizeof(buf), "promote failed: 0x%08X", lastPromoteResult_);
+        sceClibSnprintf(buf, sizeof(buf),
+                        "promote failed: 0x%08X",
+                        lastPromoteResult_);
         setError(buf);
         return InstallResult::PromoteFailed;
     }
 
-    sceClibPrintf("[HomebrewInstaller] promote OK for %s\n", dir.c_str());
+    sceClibPrintf(
+        "[HomebrewInstaller] promote OK for %s\n",
+        dir.c_str()
+    );
+
     return InstallResult::Ok;
 }
 
@@ -105,6 +241,8 @@ InstallResult HomebrewInstaller::installVpk(
 ) {
     lastError_.clear();
     lastPromoteResult_ = 0;
+    pafLoadedByUs_ = false;
+    promoterLoadedByUs_ = false;
 
     if (vpkPath.empty()) {
         setError("empty vpk path");
@@ -120,25 +258,23 @@ InstallResult HomebrewInstaller::installVpk(
     if (onProgress) {
         InstallProgress p;
         p.stage = InstallProgress::Preparing;
-        p.message = "detecting";
+        p.message = "detecting VPK";
         onProgress(p);
     }
 
     FormatDetector detector;
     DetectResult det = detector.detectFile(vpkPath);
-    if (det.format != FileFormat::Vpk && det.format != FileFormat::Zip) {
-        setError(std::string("not a vpk/zip: ") + toString(det.format));
-        return InstallResult::NotVpk;
-    }
+    const std::string ext = FormatDetector::extensionOf(vpkPath);
 
-    // Prefer .vpk extension for homebrew install path; still allow zip with vpk layout
-    std::string ext = FormatDetector::extensionOf(vpkPath);
-    if (ext != "vpk" && det.format != FileFormat::Vpk) {
-        // Allow zip only if caller insists — Phase 6 treats non-.vpk as NotVpk for safety
-        if (ext != "vpk") {
-            setError("extension is not .vpk");
-            return InstallResult::NotVpk;
-        }
+    // A VPK is a ZIP container, but a generic .zip must never be treated as
+    // an installable homebrew package. Require both the extension and magic.
+    if (ext != "vpk" || det.format != FileFormat::Vpk) {
+        setError(
+            std::string("invalid VPK: format=") +
+            toString(det.format) +
+            " ext=" + ext
+        );
+        return InstallResult::NotVpk;
     }
 
     if (shouldCancel && shouldCancel()) {
@@ -151,20 +287,25 @@ InstallResult HomebrewInstaller::installVpk(
         return InstallResult::IoError;
     }
 
-    // Unique temp dir
-    char tmpName[128];
-    sceClibSnprintf(tmpName, sizeof(tmpName), "%s/inst_%u",
-                    TMP_ROOT, (unsigned)sceKernelGetProcessTimeLow());
-    std::string tmpDir = tmpName;
+    char tmpName[160];
+    sceClibSnprintf(
+        tmpName,
+        sizeof(tmpName),
+        "%s/inst_%llu",
+        TMP_ROOT,
+        (unsigned long long)sceKernelGetProcessTimeWide()
+    );
+    const std::string tmpDir = tmpName;
 
-    // Clean if exists
-    // (simple: create fresh)
-    st.createDirectories(tmpDir);
+    if (!st.createDirectories(tmpDir)) {
+        setError("cannot create VPK temp directory");
+        return InstallResult::IoError;
+    }
 
     if (onProgress) {
         InstallProgress p;
         p.stage = InstallProgress::Extracting;
-        p.message = "extracting vpk";
+        p.message = "extracting VPK";
         onProgress(p);
     }
 
@@ -173,35 +314,51 @@ InstallResult HomebrewInstaller::installVpk(
         vpkPath,
         tmpDir,
         [&](const ZipProgress& zp) {
-            if (onProgress) {
-                InstallProgress p;
-                p.stage = InstallProgress::Extracting;
-                p.entriesDone = zp.entriesDone;
-                p.entriesTotal = zp.entriesTotal;
-                p.bytesWritten = zp.bytesWritten;
-                p.message = zp.currentEntry;
-                onProgress(p);
+            if (!onProgress) {
+                return;
             }
+
+            InstallProgress p;
+            p.stage = InstallProgress::Extracting;
+            p.entriesDone = zp.entriesDone;
+            p.entriesTotal = zp.entriesTotal;
+            p.bytesWritten = zp.bytesWritten;
+            p.message = zp.currentEntry;
+            onProgress(p);
         },
         shouldCancel
     );
 
     if (zr == ZipResult::Cancelled) {
+        removeTree(tmpDir);
         setError("extract cancelled");
         return InstallResult::Cancelled;
     }
+
     if (zr != ZipResult::Ok) {
-        setError(std::string("extract failed: ") + zip.lastError());
+        removeTree(tmpDir);
+        setError(
+            std::string("extract failed: ") + zip.lastError()
+        );
         return InstallResult::ExtractFailed;
     }
 
-    // Basic layout check: sce_sys should exist
-    if (!st.exists(tmpDir + "/sce_sys") && !st.exists(tmpDir + "/eboot.bin")) {
-        setError("extracted package missing sce_sys/eboot.bin");
+    // Minimum Vita homebrew package layout. PromoterUtil consumes the
+    // extracted directory and relies on the package metadata in param.sfo.
+    const std::string ebootPath = tmpDir + "/eboot.bin";
+    const std::string paramPath = tmpDir + "/sce_sys/param.sfo";
+
+    if (!st.exists(ebootPath) || !st.exists(paramPath)) {
+        removeTree(tmpDir);
+        setError(
+            "invalid VPK layout: expected eboot.bin and "
+            "sce_sys/param.sfo"
+        );
         return InstallResult::ExtractFailed;
     }
 
     if (shouldCancel && shouldCancel()) {
+        removeTree(tmpDir);
         setError("cancelled before promote");
         return InstallResult::Cancelled;
     }
@@ -209,42 +366,48 @@ InstallResult HomebrewInstaller::installVpk(
     if (onProgress) {
         InstallProgress p;
         p.stage = InstallProgress::Promoting;
-        p.message = "promoter";
+        p.message = "installing with Promoter Utility";
         onProgress(p);
     }
 
     if (!loadPromoterModule()) {
+        // Keep the extracted package for diagnostics if module loading fails.
         return InstallResult::ModuleFailed;
     }
 
-    InstallResult pr = promoteExtractedDir(tmpDir);
+    InstallResult result = promoteExtractedDir(tmpDir);
+    unloadPromoterModules();
 
     if (onProgress) {
         InstallProgress p;
-        p.stage = (pr == InstallResult::Ok) ? InstallProgress::Cleaning : InstallProgress::Error;
-        p.message = (pr == InstallResult::Ok) ? "cleanup" : lastError_;
+        p.stage = (result == InstallResult::Ok)
+            ? InstallProgress::Cleaning
+            : InstallProgress::Error;
+        p.message = (result == InstallResult::Ok)
+            ? "cleaning temporary files"
+            : lastError_;
         onProgress(p);
     }
 
-    if (pr == InstallResult::Ok && deleteTempOnSuccess) {
-        // Best-effort recursive cleanup is complex; remove known files shallowly
-        // Full recursive delete can be improved later.
-        // For Phase 6 we remove eboot and try rmdir tree via simple approach:
-        // leave tmp if remove fails — does not block install success.
-        st.removeFile(tmpDir + "/eboot.bin");
-        // Attempt remove dir (may fail if not empty)
-        sceIoRmdir((tmpDir + "/sce_sys").c_str());
-        sceIoRmdir(tmpDir.c_str());
+    if (result == InstallResult::Ok && deleteTempOnSuccess) {
+        if (!removeTree(tmpDir)) {
+            // Installation already succeeded. Do not turn a cleanup warning
+            // into an installation failure.
+            sceClibPrintf(
+                "[HomebrewInstaller] warning: cleanup failed for %s\n",
+                tmpDir.c_str()
+            );
+        }
     }
 
-    if (pr == InstallResult::Ok && onProgress) {
+    if (result == InstallResult::Ok && onProgress) {
         InstallProgress p;
         p.stage = InstallProgress::Done;
-        p.message = "installed";
+        p.message = "VPK installed";
         onProgress(p);
     }
 
-    return pr;
+    return result;
 }
 
 } // namespace psvitaalive


### PR DESCRIPTION
## Phase 6 validation change

This PR hardens the legitimate Homebrew VPK installation path without adding DRM/license bypass logic.

### Changes
- Require a real `.vpk` ZIP: generic `.zip` files are no longer accepted by HomebrewInstaller.
- Validate `eboot.bin` and `sce_sys/param.sfo` after extraction.
- Load PromoterUtil dependencies in the correct order, including internal PAF with the established arguments.
- Remove the invalid public-module fallback using `0x165`.
- Track modules loaded by PSVitaAlive and unload only those modules after promotion.
- Use the extracted package directory with `scePromoterUtilityPromotePkg`, matching VitaSDK documentation.
- Make temporary-directory creation mandatory instead of ignoring failure.
- Use a wider process-time value for temporary-directory uniqueness.
- Recursively clean temporary extraction data after successful installation and after extraction cancellation/failure.
- Keep extracted data on Promoter/module failure for diagnostics.

### Important scope boundary
This does not implement DRM bypass, license generation, or encrypted commercial PKG installation.

### Validation still required on the developer machine
The GitHub repository currently has no VitaSDK client build workflow, so the branch must be compiled with the installed VitaSDK before merging.
