### PR TITLE
Integrate external Homebrew catalogs, overrides and automatic synchronization

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,12 +4,28 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "apps/**"
+      - "authors/**"
+      - "categories/**"
+      - "catalog_overrides/**"
+      - "external_authors/**"
+      - "sources/**"
+      - "scripts/**"
+      - ".github/workflows/validate.yml"
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: "17 */3 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: write
+
+concurrency:
+  group: catalog-generation
+  cancel-in-progress: false
 
 jobs:
   validate-json:
@@ -30,10 +46,15 @@ jobs:
       - name: Validate historical IDs
         run: python scripts/validate_registry.py
 
-      - name: Validate VitaHub catalog
+      - name: Validate VitaHub source catalog
         run: python scripts/validate_catalog.py
 
-      - name: Generate VitaHub catalogs
+      - name: Run external aggregation smoke test
+        run: python scripts/external_smoke_test.py
+
+      - name: Generate merged VitaHub catalogs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/generate_catalog.py
 
       - name: Verify generated catalogs
@@ -41,7 +62,6 @@ jobs:
           test -f catalog.json
           test -f authors.json
           test -f categories.json
-
           python -m json.tool catalog.json > /dev/null
           python -m json.tool authors.json > /dev/null
           python -m json.tool categories.json > /dev/null
@@ -50,12 +70,12 @@ jobs:
           ls -lh catalog.json authors.json categories.json
 
       - name: Commit generated catalogs
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         run: |
-          git add catalog.json authors.json categories.json
+          git add catalog.json authors.json categories.json reports/external_conflicts.json || true
 
           if git diff --cached --quiet; then
-            echo "No catalog changes detected."
+            echo "No generated catalog changes detected."
             exit 0
           fi
 
@@ -64,4 +84,18 @@ jobs:
 
           git commit -m "Update generated VitaHub catalogs"
 
-          git push
+          for attempt in 1 2 3 4 5; do
+            if git push; then
+              break
+            fi
+            if [ "$attempt" = 5 ]; then
+              echo "::error::git push rejected after 5 attempts"
+              exit 1
+            fi
+            git fetch origin main
+            git rebase origin/main || {
+              git rebase --abort
+              git reset --soft origin/main
+              git diff --cached --quiet || git commit -m "Update generated VitaHub catalogs"
+            }
+          done

--- a/catalog_overrides/.gitkeep
+++ b/catalog_overrides/.gitkeep
@@ -1,0 +1,1 @@
+# Add one JSON file per canonical app to override or enrich selected fields.

--- a/catalog_overrides/README.md
+++ b/catalog_overrides/README.md
@@ -1,0 +1,43 @@
+# Catalog Overrides
+
+Crea un archivo JSON por aplicación usando exactamente el `id` canónico:
+
+```text
+catalog_overrides/adrenaline.json
+```
+
+El archivo solo contiene los campos que quieras cambiar o enriquecer.
+
+Permitidos como reemplazo directo:
+
+- `name`
+- `description`
+- `long_description`
+- `requirements`
+- `icon`
+- `changelog`
+
+Para listas se usa:
+
+- `replace`
+- `add`
+- `remove`
+
+Ejemplo:
+
+```json
+{
+  "id": "adrenaline",
+  "links": {
+    "add": [
+      {
+        "type": "Download",
+        "name": "Game Data",
+        "url": "https://example.com/data.zip"
+      }
+    ]
+  }
+}
+```
+
+No se permiten overrides normales para `id`, `title_id`, `author_ids`, `category_id`, `subcategory_ids`, `status`, `version`, `version_date` ni `size`.

--- a/external_authors/.gitkeep
+++ b/external_authors/.gitkeep
@@ -1,0 +1,1 @@
+# Provisional author candidates discovered from external catalogs.

--- a/external_authors/README.md
+++ b/external_authors/README.md
@@ -1,0 +1,11 @@
+# Autores externos provisionales
+
+Esta capa representa autores descubiertos automáticamente que todavía no tienen un JSON canónico en `authors/`.
+
+El `author_id` debe ser estable. Cuando el autor sea curado manualmente, crea:
+
+```text
+authors/<mismo-id>.json
+```
+
+No cambies el ID de las aplicaciones que lo utilizan.

--- a/scripts/external/__init__.py
+++ b/scripts/external/__init__.py
@@ -1,0 +1,1 @@
+"""External catalog aggregation helpers for PSVitaAlive."""

--- a/scripts/external/aggregate.py
+++ b/scripts/external/aggregate.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from .identity import canonical_author_id, same_identity
+from .merge import merge_group
+from .neovitadb import fetch_candidates as fetch_neovita
+from .overrides import apply_override, load_overrides
+from .sources import Candidate, fetch_json, normalize_vitadbtoo
+from .normalizer import canonical_repo
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG = ROOT / "sources" / "external_sources.json"
+CATEGORY_MAP = ROOT / "sources" / "category_map.json"
+
+
+def load_local():
+    apps = []
+    authors = {}
+    categories = []
+    for path in sorted((ROOT / "apps").glob("*.json")):
+        with path.open(encoding="utf-8") as f:
+            apps.append((path, json.load(f)))
+    for path in sorted((ROOT / "authors").glob("*.json")):
+        with path.open(encoding="utf-8") as f:
+            value = json.load(f)
+            authors[value["id"]] = value
+    for path in sorted((ROOT / "categories").glob("*.json")):
+        with path.open(encoding="utf-8") as f:
+            categories.append(json.load(f))
+    return apps, authors, categories
+
+
+def external_candidates():
+    with CONFIG.open(encoding="utf-8") as f:
+        config = json.load(f)
+    result = []
+    for source in config.get("sources", []):
+        if not source.get("enabled"):
+            continue
+        try:
+            if source["id"] == "vitadbtoo":
+                data = fetch_json(source["url"])
+                if isinstance(data, list):
+                    for item in data:
+                        candidate = normalize_vitadbtoo(item)
+                        if candidate.name and candidate.platform == "vita" and candidate.title_id:
+                            result.append(candidate)
+            elif source["id"] == "neovitadb":
+                for item in fetch_neovita():
+                    if item.get("platform", "vita") == "vita":
+                        from .neovitadb import normalize
+                        candidate = normalize(item)
+                        if candidate.name and candidate.title_id:
+                            result.append(candidate)
+        except Exception as exc:
+            print(f"warning: external source {source.get('id')} unavailable: {exc}", file=sys.stderr)
+    return result
+
+
+def group_candidates(candidates):
+    groups = []
+    for candidate in candidates:
+        placed = False
+        for group in groups:
+            if same_identity(candidate, group[0]):
+                group.append(candidate)
+                placed = True
+                break
+        if not placed:
+            groups.append([candidate])
+    return groups
+
+
+def category_map():
+    if not CATEGORY_MAP.exists():
+        return {}
+    with CATEGORY_MAP.open(encoding="utf-8") as f:
+        return json.load(f).get("mappings", {})
+
+
+def normalize_categories(candidate: Candidate, categories):
+    mappings = category_map()
+    raw = str(candidate.category_raw or "").strip().lower()
+    mapping = mappings.get(raw)
+    if not mapping:
+        # Safe fallback for old catalogs that use VitaDB-style generic game tags.
+        mapping = mappings.get("game") if candidate.platform == "vita" else None
+    valid = {item.get("id"): item for item in categories}
+    category_id = mapping.get("category_id") if mapping else None
+    if category_id not in valid:
+        return None, []
+    allowed = [item.get("id") for item in valid[category_id].get("subcategories", [])]
+    requested = list(mapping.get("subcategory_ids", [])) if mapping else []
+    subs = [item for item in requested if item in allowed]
+    return category_id, subs or (["other"] if "other" in allowed else ([allowed[0]] if allowed else []))
+
+
+def author_profile(author_id, name, repo_url=None):
+    links = []
+    repo = canonical_repo(repo_url)
+    if repo:
+        owner = repo.split("/", 1)[0]
+        links.append({"type": "GitHub", "name": "GitHub", "url": f"https://github.com/{owner}", "recommended": True})
+        avatar = f"https://github.com/{owner}.png"
+    else:
+        avatar = ""
+    return {"id": author_id, "name": name or author_id, "avatar": avatar, "bio": "", "links": links}
+
+
+def build(root: Path):
+    local_apps, authors, categories = load_local()
+    locals_as_candidates = []
+    local_by_id = {}
+    for _, app in local_apps:
+        repo = next((x.get("url") for x in app.get("links", []) if x.get("type") == "Repository"), None)
+        local_candidate = Candidate(
+            source_id="local", source_item_id=app.get("id"), title_id=app.get("title_id"), name=app.get("name", ""),
+            author_names=list(app.get("author_ids", [])), repository_url=repo, release_page=None,
+            version=app.get("version"), version_date=app.get("version_date"), description=app.get("description"),
+            long_description=app.get("long_description"), requirements=app.get("requirements"), changelog=app.get("changelog"),
+            icon=app.get("icon"), screenshots=list(app.get("screenshots", [])), download_url=next((x.get("url") for x in app.get("links", []) if x.get("type") == "Download" and x.get("recommended")), None),
+            size=app.get("size"), category_raw=app.get("category_id"), platform="vita")
+        locals_as_candidates.append(local_candidate)
+        local_by_id[app.get("id")] = app
+    all_candidates = locals_as_candidates + external_candidates()
+    groups = group_candidates(all_candidates)
+    overrides = load_overrides(root)
+    final_apps, final_authors = [], dict(authors)
+    conflicts = []
+    for group in groups:
+        merged = merge_group(group)
+        local = next((x for x in group if x.source_id == "local"), None)
+        app_id = local.source_item_id if local else None
+        if not app_id:
+            slug = canonical_author_id(merged.name)
+            suffix = merged.title_id.lower() if merged.title_id else "external"
+            app_id = f"{slug}-{suffix}".strip("-")
+        author_ids = []
+        for author_name in merged.author_names:
+            aid = author_name if author_name in authors else canonical_author_id(author_name)
+            author_ids.append(aid)
+            if aid not in final_authors:
+                repo_url = next((x.repository_url for x in group if author_name in x.author_names and x.repository_url), None)
+                final_authors[aid] = author_profile(aid, author_name, repo_url)
+        category_id, subcategory_ids = normalize_categories(merged, categories)
+        if not category_id:
+            conflicts.append({"type": "unmapped_category", "app": app_id, "value": merged.category_raw})
+            continue
+        app = dict(local_by_id.get(app_id, {})) if app_id in local_by_id else {}
+        app.update({
+            "id": app_id, "title_id": merged.title_id or "", "name": merged.name,
+            "description": merged.description or "", "long_description": merged.long_description or "",
+            "author_ids": list(dict.fromkeys(author_ids)), "category_id": category_id, "subcategory_ids": subcategory_ids,
+            "version": merged.version or app.get("version", "0"), "version_date": (merged.version_date or app.get("version_date") or datetime.utcnow().date().isoformat())[:10],
+            "requirements": merged.requirements or app.get("requirements", ""), "size": int(merged.size or app.get("size") or 1),
+            "status": app.get("status", "Legacy"), "icon": merged.icon or app.get("icon", ""),
+            "screenshots": merged.screenshots or app.get("screenshots", []),
+        })
+        existing_links = list(app.get("links", []))
+        if merged.download_url and not any(item.get("url") == merged.download_url for item in existing_links if isinstance(item, dict)):
+            existing_links.append({"type": "Download", "name": "External VPK", "url": merged.download_url})
+        if existing_links and not any(item.get("recommended") is True for item in existing_links if isinstance(item, dict)):
+            for item in existing_links:
+                if item.get("type") == "Download":
+                    item["recommended"] = True
+                    break
+        if merged.repository_url and not any(item.get("url") == merged.repository_url for item in existing_links if isinstance(item, dict)):
+            existing_links.append({"type": "Repository", "name": "Repositorio", "url": merged.repository_url})
+        app["links"] = existing_links
+        if app_id in overrides:
+            app = apply_override(app, overrides[app_id])
+        final_apps.append(app)
+    return final_apps, list(final_authors.values()), categories, conflicts

--- a/scripts/external/identity.py
+++ b/scripts/external/identity.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+
+from .normalizer import canonical_repo, normalize_text
+from .sources import Candidate
+
+
+def canonical_author_id(name: str) -> str:
+    value = normalize_text(name)
+    value = re.sub(r"[^a-z0-9_-]+", "-", value).strip("-")
+    return value or "unknown-author"
+
+
+def identity_keys(candidate: Candidate) -> list[tuple[str, str]]:
+    keys = []
+    if candidate.title_id:
+        keys.append(("title_id", str(candidate.title_id).strip().upper()))
+    repo = canonical_repo(candidate.repository_url)
+    if repo:
+        keys.append(("repo", repo))
+    if candidate.download_url:
+        keys.append(("download", candidate.download_url.split("?")[0].split("#")[0].rstrip("/")))
+    name = normalize_text(candidate.name)
+    authors = ",".join(sorted(canonical_author_id(item) for item in candidate.author_names))
+    if name and authors:
+        keys.append(("weak", f"{name}|{authors}"))
+    return keys
+
+
+def same_identity(left: Candidate, right: Candidate) -> bool:
+    left_keys = set(identity_keys(left))
+    right_keys = set(identity_keys(right))
+    strong_left = {item for item in left_keys if item[0] in {"title_id", "repo"}}
+    strong_right = {item for item in right_keys if item[0] in {"title_id", "repo"}}
+    return bool(strong_left & strong_right) or bool(left_keys & right_keys and not strong_left and not strong_right)
+
+
+def choose_existing_id(candidates: list[tuple[str, Candidate]]) -> str | None:
+    for source_id, candidate in candidates:
+        if source_id == "local" and candidate.source_item_id:
+            return str(candidate.source_item_id)
+    return None

--- a/scripts/external/merge.py
+++ b/scripts/external/merge.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from dataclasses import asdict
+from .identity import canonical_author_id
+from .normalizer import normalize_version
+from .sources import Candidate
+
+
+def version_key(candidate: Candidate):
+    version = normalize_version(candidate.version)
+    date = str(candidate.version_date or "")
+    stable = 0 if any(marker in str(candidate.version or "").lower() for marker in ("beta", "alpha", "rc", "nightly", "dev")) else 1
+    return (version, stable, date)
+
+
+def select_newest(candidates: list[Candidate]) -> Candidate:
+    return max(candidates, key=version_key)
+
+
+def merge_group(candidates: list[Candidate]) -> Candidate:
+    newest = select_newest(candidates)
+    local = next((item for item in candidates if item.source_id == "local"), None)
+
+    def first_value(field):
+        if local:
+            value = getattr(local, field)
+            if value not in (None, "", []):
+                return value
+        value = getattr(newest, field)
+        if value not in (None, "", []):
+            return value
+        for item in candidates:
+            value = getattr(item, field)
+            if value not in (None, "", []):
+                return value
+        return None
+
+    authors = []
+    for item in candidates:
+        for author in item.author_names:
+            if author and canonical_author_id(author) not in {canonical_author_id(x) for x in authors}:
+                authors.append(author)
+
+    screenshots = []
+    for item in ([local] if local else []) + sorted(candidates, key=version_key, reverse=True):
+        if not item:
+            continue
+        for url in item.screenshots:
+            if url and url not in screenshots:
+                screenshots.append(url)
+
+    return Candidate(
+        source_id="merged",
+        source_item_id=local.source_item_id if local else newest.source_item_id,
+        title_id=first_value("title_id"),
+        name=first_value("name") or "Unnamed Homebrew",
+        author_names=authors,
+        repository_url=first_value("repository_url"),
+        release_page=first_value("release_page"),
+        version=newest.version or first_value("version"),
+        version_date=newest.version_date or first_value("version_date"),
+        description=first_value("description"),
+        long_description=first_value("long_description"),
+        requirements=first_value("requirements"),
+        changelog=first_value("changelog"),
+        icon=first_value("icon"),
+        screenshots=screenshots[:5],
+        download_url=newest.download_url or first_value("download_url"),
+        size=newest.size or first_value("size"),
+        category_raw=local.category_raw if local and local.category_raw else first_value("category_raw"),
+        platform="vita",
+    )

--- a/scripts/external/neovitadb.py
+++ b/scripts/external/neovitadb.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from .sources import Candidate, fetch_json
+
+
+CANDIDATE_URLS = [
+    "https://robin994.github.io/NeoVitaDB-Catalog/dist/vita.json",
+    "https://robin994.github.io/NeoVitaDB-Catalog/vita.json",
+]
+
+
+def fetch_candidates():
+    last_error = None
+    for url in CANDIDATE_URLS:
+        try:
+            data = fetch_json(url)
+            if isinstance(data, list):
+                return data
+        except Exception as exc:
+            last_error = exc
+    raise RuntimeError(f"NeoVitaDB feed unavailable: {last_error}")
+
+
+def normalize(raw: dict) -> Candidate:
+    return Candidate(
+        source_id="neovitadb",
+        source_item_id=str(raw.get("id")) if raw.get("id") is not None else None,
+        title_id=raw.get("titleid") or raw.get("title_id"),
+        name=str(raw.get("name") or "").strip(),
+        author_names=[str(raw.get("author"))] if raw.get("author") else [],
+        repository_url=raw.get("repo") or raw.get("source"),
+        release_page=raw.get("release_page"),
+        version=raw.get("version"),
+        version_date=raw.get("date") or raw.get("version_date"),
+        description=raw.get("description"),
+        long_description=raw.get("long_description"),
+        requirements=raw.get("requirements"),
+        changelog=raw.get("changelog"),
+        icon=raw.get("icon") or raw.get("icon_url"),
+        screenshots=raw.get("screenshots") or raw.get("screenshot_urls") or [],
+        download_url=raw.get("url") or raw.get("download_url"),
+        size=raw.get("size") or raw.get("size_bytes"),
+        category_raw=raw.get("category") or raw.get("type"),
+        platform=raw.get("platform") or "vita",
+    )

--- a/scripts/external/normalizer.py
+++ b/scripts/external/normalizer.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+
+def normalize_text(value: str | None) -> str:
+    if not isinstance(value, str):
+        return ""
+    return re.sub(r"\\s+", " ", value.strip()).lower()
+
+
+def canonical_repo(url: str | None) -> str:
+    if not isinstance(url, str) or not url.strip():
+        return ""
+    value = url.strip().rstrip("/")
+    if value.endswith(".git"):
+        value = value[:-4]
+    parsed = urlparse(value if "://" in value else "https://" + value)
+    if parsed.netloc.lower() != "github.com":
+        return ""
+    parts = [p for p in parsed.path.split("/") if p]
+    if len(parts) < 2:
+        return ""
+    return f"{parts[0].lower()}/{parts[1].lower()}"
+
+
+def normalize_version(value: str | None) -> tuple:
+    raw = normalize_text(value)
+    raw = re.sub(r"^(version|ver|v)[:\\s-]*", "", raw)
+    match = re.findall(r"\\d+", raw)
+    if not match:
+        return (0,)
+    return tuple(int(item) for item in match)

--- a/scripts/external/overrides.py
+++ b/scripts/external/overrides.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+class OverrideError(ValueError):
+    pass
+
+
+PROTECTED = {"id", "title_id", "author_ids", "category_id", "subcategory_ids", "status"}
+CONTROLLED = {"version", "version_date", "size"}
+SCALAR_FIELDS = {"name", "description", "long_description", "requirements", "icon", "changelog"}
+ARRAY_FIELDS = {"screenshots", "links"}
+
+
+def load_overrides(root: Path) -> dict[str, dict]:
+    directory = root / "catalog_overrides"
+    result = {}
+    if not directory.exists():
+        return result
+    for path in sorted(directory.glob("*.json")):
+        with path.open("r", encoding="utf-8") as handle:
+            value = json.load(handle)
+        if not isinstance(value, dict):
+            raise OverrideError(f"{path}: root must be an object")
+        app_id = value.get("id")
+        if not isinstance(app_id, str) or not app_id:
+            raise OverrideError(f"{path}: id must be a non-empty string")
+        if path.stem != app_id:
+            raise OverrideError(f"{path}: filename must match id '{app_id}'")
+        invalid = (set(value) - {"id"} - SCALAR_FIELDS - ARRAY_FIELDS)
+        if invalid:
+            raise OverrideError(f"{path}: unsupported override fields: {sorted(invalid)}")
+        for field in PROTECTED | CONTROLLED:
+            if field in value:
+                raise OverrideError(f"{path}: '{field}' is not overrideable")
+        result[app_id] = value
+    return result
+
+
+def _merge_list(base, operation):
+    if "replace" in operation:
+        return list(operation["replace"])
+    result = list(base or [])
+    for item in operation.get("remove", []):
+        result = [existing for existing in result if existing != item]
+    for item in operation.get("add", []):
+        if item not in result:
+            result.append(item)
+    return result
+
+
+def apply_override(app: dict, override: dict) -> dict:
+    result = dict(app)
+    for field in SCALAR_FIELDS:
+        if field in override:
+            result[field] = override[field]
+    for field in ARRAY_FIELDS:
+        if field in override:
+            operation = override[field]
+            if not isinstance(operation, dict):
+                raise OverrideError(f"override {app.get('id')}: {field} must be an object")
+            result[field] = _merge_list(result.get(field), operation)
+    return result

--- a/scripts/external/sources.py
+++ b/scripts/external/sources.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+USER_AGENT = "PSVitaAlive-ExternalCatalog/1.0"
+
+
+@dataclass
+class Candidate:
+    source_id: str
+    source_item_id: str | None
+    title_id: str | None
+    name: str
+    author_names: list[str]
+    repository_url: str | None
+    release_page: str | None
+    version: str | None
+    version_date: str | None
+    description: str | None
+    long_description: str | None
+    requirements: str | None
+    changelog: str | None
+    icon: str | None
+    screenshots: list[str]
+    download_url: str | None
+    size: int | None
+    category_raw: str | None
+    platform: str | None
+
+
+def fetch_json(url: str):
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": USER_AGENT},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def _as_list(value):
+    if isinstance(value, list):
+        return [str(item) for item in value if item]
+    if isinstance(value, str) and value.strip():
+        return [value.strip()]
+    return []
+
+
+def normalize_vitadbtoo(raw: dict) -> Candidate:
+    screenshots = _as_list(raw.get("screenshots"))
+    authors = _as_list(raw.get("author") or raw.get("authors"))
+    return Candidate(
+        source_id="vitadbtoo",
+        source_item_id=str(raw.get("id")) if raw.get("id") is not None else None,
+        title_id=raw.get("titleid") or raw.get("title_id"),
+        name=str(raw.get("name") or "").strip(),
+        author_names=authors,
+        repository_url=raw.get("source"),
+        release_page=raw.get("release_page"),
+        version=raw.get("version"),
+        version_date=raw.get("date") or raw.get("version_date"),
+        description=raw.get("description"),
+        long_description=raw.get("long_description"),
+        requirements=raw.get("requirements"),
+        changelog=raw.get("changelog"),
+        icon=raw.get("icon"),
+        screenshots=screenshots,
+        download_url=raw.get("url"),
+        size=raw.get("size"),
+        category_raw=raw.get("type") or raw.get("category"),
+        platform="vita",
+    )
+
+
+def normalize_psvitaalive(raw: dict) -> Candidate:
+    authors = []
+    for author_id in raw.get("author_ids", []):
+        authors.append(str(author_id))
+    links = raw.get("links", []) if isinstance(raw.get("links"), list) else []
+    downloads = [item for item in links if item.get("type") == "Download"]
+    repo = next((item.get("url") for item in links if item.get("type") == "Repository"), None)
+    release = next((item.get("url") for item in links if item.get("type") in {"Official Website", "Repository"}), None)
+    download = next((item.get("url") for item in downloads if item.get("recommended")), None)
+    if not download and downloads:
+        download = downloads[0].get("url")
+    return Candidate(
+        source_id="local",
+        source_item_id=raw.get("id"),
+        title_id=raw.get("title_id"),
+        name=raw.get("name", ""),
+        author_names=authors,
+        repository_url=repo,
+        release_page=release,
+        version=raw.get("version"),
+        version_date=raw.get("version_date"),
+        description=raw.get("description"),
+        long_description=raw.get("long_description"),
+        requirements=raw.get("requirements"),
+        changelog=raw.get("changelog"),
+        icon=raw.get("icon"),
+        screenshots=list(raw.get("screenshots", [])),
+        download_url=download,
+        size=raw.get("size"),
+        category_raw=raw.get("category_id"),
+        platform="vita",
+    )

--- a/scripts/external_smoke_test.py
+++ b/scripts/external_smoke_test.py
@@ -4,10 +4,10 @@
 from pathlib import Path
 import tempfile
 
-from scripts.external.identity import canonical_author_id, same_identity
-from scripts.external.merge import select_newest
-from scripts.external.overrides import load_overrides, apply_override
-from scripts.external.sources import Candidate
+from external.identity import canonical_author_id, same_identity
+from external.merge import select_newest
+from external.overrides import load_overrides, apply_override
+from external.sources import Candidate
 
 
 def candidate(source, version, title="TEST00001"):

--- a/scripts/external_smoke_test.py
+++ b/scripts/external_smoke_test.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Offline smoke tests for the external aggregation primitives."""
+
+from pathlib import Path
+import tempfile
+
+from scripts.external.identity import canonical_author_id, same_identity
+from scripts.external.merge import select_newest
+from scripts.external.overrides import load_overrides, apply_override
+from scripts.external.sources import Candidate
+
+
+def candidate(source, version, title="TEST00001"):
+    return Candidate(
+        source_id=source,
+        source_item_id=source,
+        title_id=title,
+        name="Example Homebrew",
+        author_names=["ExampleDev"],
+        repository_url="https://github.com/example/project",
+        release_page=None,
+        version=version,
+        version_date="2026-08-12",
+        description="description",
+        long_description="long",
+        requirements="",
+        changelog="",
+        icon="https://example/icon.png",
+        screenshots=["https://example/1.png"],
+        download_url="https://example/app.vpk",
+        size=123,
+        category_raw="game",
+        platform="vita",
+    )
+
+
+a = candidate("a", "1.9")
+b = candidate("b", "1.10")
+assert select_newest([a, b]).version == "1.10"
+assert same_identity(a, b)
+assert canonical_author_id("Example Developer") == "example-developer"
+
+with tempfile.TemporaryDirectory() as temp:
+    root = Path(temp)
+    directory = root / "catalog_overrides"
+    directory.mkdir()
+    (directory / "example.json").write_text(
+        '{"id":"example","description":"Editorial","links":{"add":[{"type":"Download","name":"Game Data","url":"https://example/data.zip"}]}}\n',
+        encoding="utf-8",
+    )
+    overrides = load_overrides(root)
+    result = apply_override({"id":"example","description":"Old","links":[]}, overrides["example"])
+    assert result["description"] == "Editorial"
+    assert result["links"][0]["name"] == "Game Data"
+
+print("External aggregation smoke tests passed.")

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -10,7 +10,7 @@ ROOT = Path(__file__).resolve().parents[1]
 def repository_relative_resource(value, source_directory):
     if not isinstance(value, str) or not value.strip():
         return value
-    if value.startswith("http://") or value.startswith("https://"):
+    if value.startswith(("http://", "https://")):
         return value
     local = (source_directory / value).resolve()
     try:
@@ -18,10 +18,6 @@ def repository_relative_resource(value, source_directory):
     except ValueError as exc:
         raise ValueError(f"resource escapes repository: {value}") from exc
     return relative.as_posix()
-
-
-def normalize_final_resource(value, source_directory):
-    return repository_relative_resource(value, source_directory)
 
 
 def validate_final(apps, authors, categories):
@@ -37,20 +33,19 @@ def validate_final(apps, authors, categories):
         if not title_id or title_id in title_ids:
             raise ValueError(f"duplicate/empty title_id: {title_id}")
         title_ids.add(title_id)
-        authors_for_app = app.get("author_ids")
-        if not isinstance(authors_for_app, list) or not authors_for_app:
+        author_list = app.get("author_ids")
+        if not isinstance(author_list, list) or not author_list:
             raise ValueError(f"{app['id']}: author_ids must be non-empty")
-        missing = [item for item in authors_for_app if item not in author_ids]
+        missing = [item for item in author_list if item not in author_ids]
         if missing:
             raise ValueError(f"{app['id']}: unknown author_ids: {missing}")
-        category_id = app.get("category_id")
-        category = category_map.get(category_id)
+        category = category_map.get(app.get("category_id"))
         if not category:
-            raise ValueError(f"{app['id']}: unknown category_id {category_id}")
+            raise ValueError(f"{app['id']}: unknown category_id {app.get('category_id')}")
         allowed = {item.get("id") for item in category.get("subcategories", [])}
         for sub_id in app.get("subcategory_ids", []):
             if sub_id not in allowed:
-                raise ValueError(f"{app['id']}: subcategory {sub_id} is not valid for {category_id}")
+                raise ValueError(f"{app['id']}: invalid subcategory {sub_id}")
         screenshots = app.get("screenshots") or []
         if screenshots and not 1 <= len(screenshots) <= 5:
             raise ValueError(f"{app['id']}: screenshots must contain 1-5 items")
@@ -58,6 +53,50 @@ def validate_final(apps, authors, categories):
         recommended = sum(1 for link in links if isinstance(link, dict) and link.get("recommended") is True)
         if recommended > 1:
             raise ValueError(f"{app['id']}: more than one recommended link")
+
+
+def process_media(apps):
+    local_paths = {}
+    for path in sorted((ROOT / "apps").glob("*.json")):
+        try:
+            with path.open(encoding="utf-8") as handle:
+                data = json.load(handle)
+            local_paths[data.get("id")] = path.parent
+        except Exception:
+            continue
+
+    category_icons = {}
+    for path in sorted((ROOT / "categories").glob("*.json")):
+        with path.open(encoding="utf-8") as handle:
+            category = json.load(handle)
+        icon = category.get("icon")
+        if isinstance(icon, str) and icon.strip():
+            category_icons[category.get("id")] = repository_relative_resource(icon, path.parent)
+
+    default_author_avatar = ROOT / "authors" / "icon" / "autoricon.png"
+    default_author_avatar_rel = repository_relative_resource("icon/autoricon.png", ROOT / "authors")
+
+    for app in apps:
+        source_dir = local_paths.get(app.get("id"), ROOT)
+        icon = app.get("icon")
+        if not isinstance(icon, str) or not icon.strip():
+            icon = category_icons.get(app.get("category_id"), "")
+        if icon:
+            app["icon"] = repository_relative_resource(icon, source_dir if not icon.startswith(("http://", "https://")) else ROOT)
+
+        screenshots = app.get("screenshots") or []
+        if not screenshots and app.get("icon"):
+            screenshots = [app["icon"]]
+        normalized = []
+        for screenshot in screenshots:
+            if isinstance(screenshot, str) and screenshot.startswith(("http://", "https://")):
+                normalized.append(screenshot)
+            else:
+                normalized.append(repository_relative_resource(screenshot, source_dir))
+        app["screenshots"] = normalized[:5]
+
+    if not default_author_avatar.is_file():
+        raise ValueError("authors/icon/autoricon.png is required")
 
 
 def generate():
@@ -72,29 +111,26 @@ def generate():
             handle.write("\n")
         print(f"External aggregation reported {len(conflicts)} conflicts", file=sys.stderr)
 
-    # Resolve local resource references where possible. External URLs remain untouched.
-    for app in apps:
-        for field in ("icon",):
-            if isinstance(app.get(field), str) and not app[field].startswith(("http://", "https://")):
-                app[field] = normalize_final_resource(app[field], ROOT / "apps")
-        shots = []
-        for shot in app.get("screenshots", []):
-            if isinstance(shot, str) and not shot.startswith(("http://", "https://")):
-                shots.append(normalize_final_resource(shot, ROOT / "apps"))
-            else:
-                shots.append(shot)
-        app["screenshots"] = shots[:5]
+    # Keep the previous generator's icon/screenshot fallback behavior intact.
+    process_media(apps)
+
+    for author in authors:
+        avatar = author.get("avatar")
+        if not isinstance(avatar, str) or not avatar.strip():
+            author["avatar"] = "icon/autoricon.png"
 
     validate_final(apps, authors, categories)
-    with (ROOT / "catalog.json").open("w", encoding="utf-8") as f:
-        json.dump(apps, f, ensure_ascii=False, indent=2)
-        f.write("\n")
-    with (ROOT / "authors.json").open("w", encoding="utf-8") as f:
-        json.dump(authors, f, ensure_ascii=False, indent=2)
-        f.write("\n")
-    with (ROOT / "categories.json").open("w", encoding="utf-8") as f:
-        json.dump(categories, f, ensure_ascii=False, indent=2)
-        f.write("\n")
+
+    with (ROOT / "catalog.json").open("w", encoding="utf-8") as handle:
+        json.dump(apps, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+    with (ROOT / "authors.json").open("w", encoding="utf-8") as handle:
+        json.dump(authors, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+    with (ROOT / "categories.json").open("w", encoding="utf-8") as handle:
+        json.dump(categories, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+
     print(f"Applications: {len(apps)}")
     print(f"Authors: {len(authors)}")
     print(f"Categories: {len(categories)}")

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -74,7 +74,6 @@ def process_media(apps):
             category_icons[category.get("id")] = repository_relative_resource(icon, path.parent)
 
     default_author_avatar = ROOT / "authors" / "icon" / "autoricon.png"
-    default_author_avatar_rel = repository_relative_resource("icon/autoricon.png", ROOT / "authors")
 
     for app in apps:
         source_dir = local_paths.get(app.get("id"), ROOT)
@@ -82,7 +81,7 @@ def process_media(apps):
         if not isinstance(icon, str) or not icon.strip():
             icon = category_icons.get(app.get("category_id"), "")
         if icon:
-            app["icon"] = repository_relative_resource(icon, source_dir if not icon.startswith(("http://", "https://")) else ROOT)
+            app["icon"] = repository_relative_resource(icon, source_dir)
 
         screenshots = app.get("screenshots") or []
         if not screenshots and app.get("icon"):
@@ -100,7 +99,7 @@ def process_media(apps):
 
 
 def generate():
-    from scripts.external.aggregate import build
+    from external.aggregate import build
 
     apps, authors, categories, conflicts = build(ROOT)
     if conflicts:
@@ -111,7 +110,6 @@ def generate():
             handle.write("\n")
         print(f"External aggregation reported {len(conflicts)} conflicts", file=sys.stderr)
 
-    # Keep the previous generator's icon/screenshot fallback behavior intact.
     process_media(apps)
 
     for author in authors:

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -3,207 +3,106 @@
 import json
 import sys
 from pathlib import Path
-from urllib.parse import urlparse
-
 
 ROOT = Path(__file__).resolve().parents[1]
 
-APP_DIR = ROOT / "apps"
-AUTHOR_DIR = ROOT / "authors"
-CATEGORY_DIR = ROOT / "categories"
-
-CATALOG_FILE = ROOT / "catalog.json"
-AUTHORS_FILE = ROOT / "authors.json"
-CATEGORIES_FILE = ROOT / "categories.json"
-
-DEFAULT_AUTHOR_AVATAR = AUTHOR_DIR / "icon" / "autoricon.png"
-
-
-def load_json_directory(directory):
-    items = []
-
-    if not directory.exists():
-        return items
-
-    for path in sorted(directory.glob("*.json")):
-        with path.open("r", encoding="utf-8") as handle:
-            data = json.load(handle)
-
-        if not isinstance(data, dict):
-            raise ValueError(
-                f"{path.relative_to(ROOT)} must contain a JSON object"
-            )
-
-        items.append((path, data))
-
-    return items
-
-
-def write_json(path, data):
-    with path.open("w", encoding="utf-8") as handle:
-        json.dump(data, handle, ensure_ascii=False, indent=2)
-        handle.write("\n")
-
-
-def is_remote_resource(value):
-    if not isinstance(value, str):
-        return False
-
-    return urlparse(value).scheme in {"http", "https"}
-
 
 def repository_relative_resource(value, source_directory):
-    """Convert a local resource to a repository-relative path."""
-    if is_remote_resource(value):
+    if not isinstance(value, str) or not value.strip():
         return value
-
+    if value.startswith("http://") or value.startswith("https://"):
+        return value
     local = (source_directory / value).resolve()
-
     try:
         relative = local.relative_to(ROOT.resolve())
     except ValueError as exc:
-        raise ValueError(
-            f"resource escapes repository: {value}"
-        ) from exc
-
+        raise ValueError(f"resource escapes repository: {value}") from exc
     return relative.as_posix()
 
 
-def get_category_icons(categories):
-    result = {}
-
-    for path, category in categories:
-        category_id = category.get("id")
-        if not category_id:
-            continue
-
-        icon = category.get("icon")
-
-        if not isinstance(icon, str) or not icon.strip():
-            raise ValueError(
-                f"{path.relative_to(ROOT)} has no valid icon"
-            )
-
-        result[category_id] = repository_relative_resource(
-            icon,
-            path.parent,
-        )
-
-    return result
+def normalize_final_resource(value, source_directory):
+    return repository_relative_resource(value, source_directory)
 
 
-def process_application(path, app, category_icons):
-    """Build the final application object with media fallbacks."""
-    result = dict(app)
-    category_id = app.get("category_id")
-
-    app_icon = app.get("icon")
-
-    if isinstance(app_icon, str) and app_icon.strip():
-        final_icon = repository_relative_resource(
-            app_icon,
-            path.parent,
-        )
-    else:
-        final_icon = category_icons.get(category_id)
-        if not final_icon:
-            raise ValueError(
-                f"{path.relative_to(ROOT)} has no icon and its category has no icon"
-            )
-
-    result["icon"] = final_icon
-
-    screenshots = app.get("screenshots")
-
-    if screenshots is None or screenshots == []:
-        result["screenshots"] = [final_icon]
-    else:
-        if not isinstance(screenshots, list):
-            raise ValueError(
-                f"{path.relative_to(ROOT)} 'screenshots' must be an array"
-            )
-
-        if not 1 <= len(screenshots) <= 5:
-            raise ValueError(
-                f"{path.relative_to(ROOT)} 'screenshots' must contain between 1 and 5 images"
-            )
-
-        result["screenshots"] = [
-            repository_relative_resource(screenshot, path.parent)
-            for screenshot in screenshots
-        ]
-
-    return result
-
-
-def process_author(path, author):
-    """Build the final author object with the common avatar fallback."""
-    result = dict(author)
-    avatar = author.get("avatar")
-
-    if isinstance(avatar, str) and avatar.strip():
-        result["avatar"] = repository_relative_resource(
-            avatar,
-            path.parent,
-        )
-        return result
-
-    if not DEFAULT_AUTHOR_AVATAR.is_file():
-        raise ValueError(
-            "authors/icon/autoricon.png is required when an author has no avatar"
-        )
-
-    result["avatar"] = repository_relative_resource(
-        "icon/autoricon.png",
-        AUTHOR_DIR,
-    )
-
-    return result
+def validate_final(apps, authors, categories):
+    author_ids = {item.get("id") for item in authors}
+    category_map = {item.get("id"): item for item in categories}
+    title_ids = set()
+    app_ids = set()
+    for app in apps:
+        if not app.get("id") or app["id"] in app_ids:
+            raise ValueError(f"duplicate/empty application id: {app.get('id')}")
+        app_ids.add(app["id"])
+        title_id = app.get("title_id")
+        if not title_id or title_id in title_ids:
+            raise ValueError(f"duplicate/empty title_id: {title_id}")
+        title_ids.add(title_id)
+        authors_for_app = app.get("author_ids")
+        if not isinstance(authors_for_app, list) or not authors_for_app:
+            raise ValueError(f"{app['id']}: author_ids must be non-empty")
+        missing = [item for item in authors_for_app if item not in author_ids]
+        if missing:
+            raise ValueError(f"{app['id']}: unknown author_ids: {missing}")
+        category_id = app.get("category_id")
+        category = category_map.get(category_id)
+        if not category:
+            raise ValueError(f"{app['id']}: unknown category_id {category_id}")
+        allowed = {item.get("id") for item in category.get("subcategories", [])}
+        for sub_id in app.get("subcategory_ids", []):
+            if sub_id not in allowed:
+                raise ValueError(f"{app['id']}: subcategory {sub_id} is not valid for {category_id}")
+        screenshots = app.get("screenshots") or []
+        if screenshots and not 1 <= len(screenshots) <= 5:
+            raise ValueError(f"{app['id']}: screenshots must contain 1-5 items")
+        links = app.get("links") or []
+        recommended = sum(1 for link in links if isinstance(link, dict) and link.get("recommended") is True)
+        if recommended > 1:
+            raise ValueError(f"{app['id']}: more than one recommended link")
 
 
 def generate():
-    print("Generating VitaHub catalogs...")
+    from scripts.external.aggregate import build
 
-    app_items = load_json_directory(APP_DIR)
-    author_items = load_json_directory(AUTHOR_DIR)
-    category_items = load_json_directory(CATEGORY_DIR)
+    apps, authors, categories, conflicts = build(ROOT)
+    if conflicts:
+        report_dir = ROOT / "reports"
+        report_dir.mkdir(exist_ok=True)
+        with (report_dir / "external_conflicts.json").open("w", encoding="utf-8") as handle:
+            json.dump(conflicts, handle, ensure_ascii=False, indent=2)
+            handle.write("\n")
+        print(f"External aggregation reported {len(conflicts)} conflicts", file=sys.stderr)
 
-    category_icons = get_category_icons(category_items)
+    # Resolve local resource references where possible. External URLs remain untouched.
+    for app in apps:
+        for field in ("icon",):
+            if isinstance(app.get(field), str) and not app[field].startswith(("http://", "https://")):
+                app[field] = normalize_final_resource(app[field], ROOT / "apps")
+        shots = []
+        for shot in app.get("screenshots", []):
+            if isinstance(shot, str) and not shot.startswith(("http://", "https://")):
+                shots.append(normalize_final_resource(shot, ROOT / "apps"))
+            else:
+                shots.append(shot)
+        app["screenshots"] = shots[:5]
 
-    applications = [
-        process_application(path, app, category_icons)
-        for path, app in app_items
-    ]
-
-    authors = [
-        process_author(path, author)
-        for path, author in author_items
-    ]
-
-    categories = [data for _, data in category_items]
-
-    write_json(CATALOG_FILE, applications)
-    write_json(AUTHORS_FILE, authors)
-    write_json(CATEGORIES_FILE, categories)
-
-    print()
-    print("Catalogs generated successfully.")
-    print()
-    print(f"Applications: {len(applications)}")
+    validate_final(apps, authors, categories)
+    with (ROOT / "catalog.json").open("w", encoding="utf-8") as f:
+        json.dump(apps, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    with (ROOT / "authors.json").open("w", encoding="utf-8") as f:
+        json.dump(authors, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    with (ROOT / "categories.json").open("w", encoding="utf-8") as f:
+        json.dump(categories, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    print(f"Applications: {len(apps)}")
     print(f"Authors: {len(authors)}")
     print(f"Categories: {len(categories)}")
-    print()
-    print(f"Generated: {CATALOG_FILE.relative_to(ROOT)}")
-    print(f"Generated: {AUTHORS_FILE.relative_to(ROOT)}")
-    print(f"Generated: {CATEGORIES_FILE.relative_to(ROOT)}")
 
 
 if __name__ == "__main__":
     try:
         generate()
     except Exception as exc:
-        print()
-        print("VitaHub catalog generation failed:")
-        print(f"- {type(exc).__name__}: {exc}")
-        print()
+        print(f"VitaHub catalog generation failed: {type(exc).__name__}: {exc}", file=sys.stderr)
         sys.exit(1)

--- a/sources/README.md
+++ b/sources/README.md
@@ -1,0 +1,12 @@
+# Fuentes externas
+
+`external_sources.json` define las fuentes automáticas.
+
+Actualmente:
+
+- VitaDBtoo
+- NeoVitaDB
+
+La fuente externa nunca reemplaza la taxonomía de PSVitaAlive. `category_map.json` convierte las categorías externas a categorías/subcategorías oficiales.
+
+Las fuentes son consultadas desde GitHub Actions. El cliente PS Vita y la web continúan consumiendo únicamente los catálogos generados.

--- a/sources/category_map.json
+++ b/sources/category_map.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "mappings": {
+    "port": {"category_id": "ports", "subcategory_ids": ["other"]},
+    "plugin": {"category_id": "plugins", "subcategory_ids": ["other"]},
+    "emulator": {"category_id": "emulators", "subcategory_ids": ["other"]},
+    "utility": {"category_id": "utilities", "subcategory_ids": ["other"]},
+    "game": {"category_id": "games", "subcategory_ids": ["other"]}
+  }
+}

--- a/sources/external_sources.json
+++ b/sources/external_sources.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "sources": [
+    {
+      "id": "vitadbtoo",
+      "name": "VitaDBtoo",
+      "enabled": true,
+      "kind": "github_json",
+      "url": "https://raw.githubusercontent.com/DrDecki/VitaDBtoo-db/main/apps.json",
+      "priority": 100
+    },
+    {
+      "id": "neovitadb",
+      "name": "NeoVitaDB",
+      "enabled": true,
+      "kind": "github_catalog",
+      "url": "https://robin994.github.io/NeoVitaDB-Catalog/",
+      "priority": 90
+    }
+  ]
+}


### PR DESCRIPTION
## Resumen
Integra la capa de agregación externa de Homebrew manteniendo la arquitectura actual de PSVitaAlive.

### Incluye
- VitaDBtoo como fuente externa.
- NeoVitaDB como fuente externa configurable.
- Resolución de identidad por Title ID/repositorio.
- Resolución de la versión más reciente.
- Fusión de metadata sin perder información local.
- `catalog_overrides/` para curación editorial.
- Autores externos provisionales y múltiples autores.
- Mapeo exclusivo a categorías/subcategorías oficiales.
- Múltiples links y Game Data.
- Sincronización externa cada 3 horas.
- Ejecución inmediata ante cambios en `apps/`, `authors/`, `categories/` o `catalog_overrides/`.
- Smoke tests offline.

Web y cliente PS Vita continúan consumiendo únicamente `catalog.json`, `authors.json` y `categories.json`.