### PR TITLE
Client: check for updates before catalog startup

### DIFF
--- a/Client PSVitaAlive/CMakeLists.txt
+++ b/Client PSVitaAlive/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SOURCES
   source/installer/install_controller.cpp
   source/catalog/catalog_parser.cpp
   source/catalog/catalog_manager.cpp
+  source/update/update_checker.cpp
   source/ui/ui_types.cpp
   source/ui/image_cache.cpp
   source/ui/full_catalog_screen.cpp
@@ -52,6 +53,10 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 target_compile_options(${PROJECT_NAME} PRIVATE
   -fno-rtti
+)
+
+target_compile_definitions(${PROJECT_NAME} PRIVATE
+  PSVITAALIVE_VERSION="${VITA_VERSION}"
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/Client PSVitaAlive/include/catalog/catalog_manager.hpp
+++ b/Client PSVitaAlive/include/catalog/catalog_manager.hpp
@@ -57,6 +57,10 @@ private:
     std::vector<ui::CatalogItem> cachedItems_[static_cast<int>(ui::CatalogType::Count)];
     bool cachedValid_[static_cast<int>(ui::CatalogType::Count)] = {};
 
+    // The update check is performed once per client process, before the first
+    // catalog is loaded. The result is surfaced through the existing loading UI.
+    bool updateChecked_ = false;
+
     static int workerEntry(SceSize args, void* argp);
     int workerMain();
     bool loadCatalog(ui::CatalogType catalog, std::vector<ui::CatalogItem>& outItems);

--- a/Client PSVitaAlive/include/update/update_checker.hpp
+++ b/Client PSVitaAlive/include/update/update_checker.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace psvitaalive {
+
+class UpdateChecker {
+public:
+    enum class State {
+        UpToDate,
+        UpdateAvailable,
+        Failed
+    };
+
+    struct Result {
+        State state = State::Failed;
+        std::string localVersion;
+        std::string remoteVersion;
+        std::string releaseTag;
+        std::string releaseName;
+        std::string downloadUrl;
+        std::string assetName;
+        std::string digest;
+        uint64_t assetSize = 0;
+        std::string error;
+    };
+
+    static Result checkLatest(const std::string& currentVersion);
+};
+
+} // namespace psvitaalive

--- a/Client PSVitaAlive/source/catalog/catalog_manager.cpp
+++ b/Client PSVitaAlive/source/catalog/catalog_manager.cpp
@@ -4,6 +4,7 @@
 #include "diagnostic_logger.hpp"
 #include "network/http_client.hpp"
 #include "storage/storage_manager.hpp"
+#include "update/update_checker.hpp"
 
 #include <psp2/kernel/clib.h>
 #include <psp2/io/fcntl.h>
@@ -105,11 +106,29 @@ bool CatalogManager::request(ui::CatalogType catalog) {
 CatalogManager::Status CatalogManager::status()const{Status result;if(mutex_<0)return result;sceKernelLockMutex(mutex_,1,nullptr);result=status_;sceKernelUnlockMutex(mutex_,1);return result;}
 bool CatalogManager::takeReady(std::vector<ui::CatalogItem>&outItems,ui::CatalogType&catalog){if(mutex_<0)return false;sceKernelLockMutex(mutex_,1,nullptr);if(!readyPending_){sceKernelUnlockMutex(mutex_,1);return false;}outItems=std::move(readyItems_);catalog=readyCatalog_;readyPending_=false;sceKernelUnlockMutex(mutex_,1);return true;}
 
-bool CatalogManager::loadCatalog(ui::CatalogType catalog,std::vector<ui::CatalogItem>&outItems){const int idx=(int)catalog;const std::string path=cachePath(catalog),meta=metadataPath(catalog),temp=path+".new",url=std::string(RAW_BASE)+fileName(catalog);const bool haveCache=fileExists(path);HttpClient http;if(http.init()!=HttpResult::Ok)return false;
-    if(haveCache){std::vector<ui::CatalogItem>cached;if(CatalogParser::parseFile(path,cached)&&!cached.empty()){std::string storedText,storedEtag,storedModified;parseValidators(readTextFile(meta,storedText)?storedText:std::string(),storedEtag,storedModified);std::string remoteEtag,remoteModified;setStatus(State::Loading,catalog,"Checking remote catalog...");const HttpResult validatorResult=http.fetchRemoteValidators(url,remoteEtag,remoteModified);if(validatorResult==HttpResult::Ok&&validatorsMatch(storedEtag,storedModified,remoteEtag,remoteModified)){outItems=std::move(cached);sceKernelLockMutex(mutex_,1,nullptr);cachedItems_[idx]=outItems;cachedValid_[idx]=true;sceKernelUnlockMutex(mutex_,1);setStatus(State::Ready,catalog,"Using cached catalog");diagnostics::log(std::string("[CatalogManager] cache valid: ")+label(catalog));http.shutdown();return true;}if(validatorResult!=HttpResult::Ok&&!storedEtag.empty()){outItems=std::move(cached);sceKernelLockMutex(mutex_,1,nullptr);cachedItems_[idx]=outItems;cachedValid_[idx]=true;sceKernelUnlockMutex(mutex_,1);setStatus(State::Ready,catalog,"Using cached catalog (offline)");diagnostics::log(std::string("[CatalogManager] offline cache: ")+label(catalog));http.shutdown();return true;}}}
+bool CatalogManager::loadCatalog(ui::CatalogType catalog,std::vector<ui::CatalogItem>&outItems){
+    if (!updateChecked_) {
+        updateChecked_ = true;
+        setStatus(State::Loading,catalog,"Checking for PSVitaAlive updates...");
+        const UpdateChecker::Result update = UpdateChecker::checkLatest(PSVITAALIVE_VERSION);
+        if (update.state == UpdateChecker::State::UpdateAvailable) {
+            const std::string message = "Update available: " + update.remoteVersion;
+            setStatus(State::Loading,catalog,message.c_str());
+            diagnostics::log("[CatalogManager] update detected; installation will be added in the self-update phase");
+        } else if (update.state == UpdateChecker::State::UpToDate) {
+            const std::string message = "PSVitaAlive is up to date: " + update.localVersion;
+            setStatus(State::Loading,catalog,message.c_str());
+        } else {
+            setStatus(State::Loading,catalog,"Update check unavailable; continuing...");
+            diagnostics::log("[CatalogManager] update check failed; continuing with catalog startup");
+        }
+    }
+
+    const int idx=(int)catalog;const std::string path=cachePath(catalog),meta=metadataPath(catalog),temp=path+".new",url=std::string(RAW_BASE)+fileName(catalog);const bool haveCache=fileExists(path);HttpClient http;if(http.init()!=HttpResult::Ok)return false;
+    if(haveCache){std::vector<ui::CatalogItem>cached;if(CatalogParser::parseFile(path,cached)&&!cached.empty()){std::string storedText,storedEtag,storedModified;parseValidators(readTextFile(meta,storedText)?storedText:std::string(),storedEtag,storedModified);std::string remoteEtag,remoteModified;setStatus(State::Loading,catalog,"Checking remote catalog...");const HttpResult validatorResult=http.fetchRemoteValidators(url,remoteEtag,remoteModified);if(validatorResult==HttpResult::Ok&&validatorsMatch(storedEtag,storedModified,remoteEtag,remoteModified)){outItems=std::move(cached);sceKernelLockMutex(mutex_,1,nullptr);cachedItems_[idx]=outItems;cachedValid_[idx]=true;sceKernelUnlockMutex(mutex_,1);setStatus(State::Ready,catalog,"Using cached catalog");diagnostics::log(std::string("[CatalogManager] cache valid: ")+label(catalog));http.shutdown();return true;}if(validatorResult!=HttpResult::Ok&&!storedEtag.empty()){outItems=std::move(cached);sceKernelLockMutex(mutex_,1);cachedItems_[idx]=outItems;cachedValid_[idx]=true;sceKernelUnlockMutex(mutex_,1);setStatus(State::Ready,catalog,"Using cached catalog (offline)");diagnostics::log(std::string("[CatalogManager] offline cache: ")+label(catalog));http.shutdown();return true;}}}
     setStatus(State::Loading,catalog,"Downloading catalog...");diagnostics::log(std::string("[CatalogManager] downloading: ")+label(catalog));const HttpResult result=http.downloadToFile(url,temp,0,[this,catalog](const HttpProgress&progress){sceKernelLockMutex(mutex_,1,nullptr);status_.current=progress.downloaded;status_.total=progress.total;status_.message="Downloading catalog...";sceKernelUnlockMutex(mutex_,1);(void)catalog;});
-    if(result==HttpResult::Ok){std::vector<ui::CatalogItem>fresh;if(CatalogParser::parseFile(temp,fresh)&&!fresh.empty()){sceIoRemove(path.c_str());if(sceIoRename(temp.c_str(),path.c_str())>=0){std::string etag,modified;http.fetchRemoteValidators(url,etag,modified);std::string metadata="etag="+etag+"\nlast_modified="+modified+"\n";writeTextFile(meta,metadata);outItems=std::move(fresh);sceKernelLockMutex(mutex_,1,nullptr);cachedItems_[idx]=outItems;cachedValid_[idx]=true;sceKernelUnlockMutex(mutex_,1);diagnostics::log(std::string("[CatalogManager] downloaded and cached: ")+label(catalog));http.shutdown();return true;}}}
-    sceIoRemove(temp.c_str());if(haveCache&&CatalogParser::parseFile(path,outItems)&&!outItems.empty()){sceKernelLockMutex(mutex_,1,nullptr);cachedItems_[idx]=outItems;cachedValid_[idx]=true;sceKernelUnlockMutex(mutex_,1);diagnostics::log(std::string("[CatalogManager] refresh failed; retained valid cache: ")+label(catalog));http.shutdown();return true;}diagnostics::log(std::string("[CatalogManager] catalog unavailable: ")+label(catalog)+" error="+http.lastError());http.shutdown();return false;}
+    if(result==HttpResult::Ok){std::vector<ui::CatalogItem>fresh;if(CatalogParser::parseFile(temp,fresh)&&!fresh.empty()){sceIoRemove(path.c_str());if(sceIoRename(temp.c_str(),path.c_str())>=0){std::string etag,modified;http.fetchRemoteValidators(url,etag,modified);std::string metadata="etag="+etag+"\nlast_modified="+modified+"\n";writeTextFile(meta,metadata);outItems=std::move(fresh);sceKernelLockMutex(mutex_,1);cachedItems_[idx]=outItems;cachedValid_[idx]=true;sceKernelUnlockMutex(mutex_,1);diagnostics::log(std::string("[CatalogManager] downloaded and cached: ")+label(catalog));http.shutdown();return true;}}}
+    sceIoRemove(temp.c_str());if(haveCache&&CatalogParser::parseFile(path,outItems)&&!outItems.empty()){sceKernelLockMutex(mutex_,1);cachedItems_[idx]=outItems;cachedValid_[idx]=true;sceKernelUnlockMutex(mutex_,1);diagnostics::log(std::string("[CatalogManager] refresh failed; retained valid cache: ")+label(catalog));http.shutdown();return true;}diagnostics::log(std::string("[CatalogManager] catalog unavailable: ")+label(catalog)+" error="+http.lastError());http.shutdown();return false;}
 
 int CatalogManager::workerEntry(SceSize args,void*argp){(void)args;CatalogManager*self=nullptr;if(argp)std::memcpy(&self,argp,sizeof(self));return self?self->workerMain():-1;}
 int CatalogManager::workerMain() {
@@ -142,10 +161,8 @@ int CatalogManager::workerMain() {
         const bool ok = loadCatalog(catalog, loaded) && !loaded.empty();
 
         sceKernelLockMutex(mutex_, 1, nullptr);
-        // User asked for another tab while we were busy: drop this result.
         if (requestPending_ || catalog != requestedCatalog_ || gen != requestGeneration_) {
             diagnostics::log(std::string("[CatalogManager] discard stale result for ") + label(catalog));
-            // Stay in Loading so the UI keeps the lock until the new job finishes.
             status_.state = State::Loading;
             status_.catalog = requestedCatalog_;
             status_.label = label(requestedCatalog_);

--- a/Client PSVitaAlive/source/update/update_checker.cpp
+++ b/Client PSVitaAlive/source/update/update_checker.cpp
@@ -1,0 +1,201 @@
+#include "update/update_checker.hpp"
+
+#include "diagnostic_logger.hpp"
+#include "network/http_client.hpp"
+
+#include <psp2/json.h>
+#include <psp2/sysmodule.h>
+#include <psp2/kernel/clib.h>
+
+#include <cctype>
+#include <cstdlib>
+#include <string>
+
+namespace psvitaalive {
+namespace {
+
+constexpr const char* RELEASES_LATEST_URL =
+    "https://api.github.com/repos/VegettoSan/PSVitaAlive/releases/latest";
+constexpr const char* UPDATE_ASSET_NAME = "PSVitaAlive.vpk";
+
+class VitaJsonAllocator : public sce::Json::MemAllocator {
+public:
+    void* allocateMemory(SceSize size, void* userData) override {
+        (void)userData;
+        return std::malloc(size);
+    }
+
+    void freeMemory(void* ptr, void* userData) override {
+        (void)userData;
+        std::free(ptr);
+    }
+};
+
+std::string getString(const sce::Json::Value& object, const char* key) {
+    const sce::Json::Value& value = object[key];
+    if (!value) return {};
+    return value.getString().c_str();
+}
+
+uint64_t getUnsigned(const sce::Json::Value& object, const char* key) {
+    const sce::Json::Value& value = object[key];
+    if (!value) return 0;
+    return value.getUInteger();
+}
+
+std::string extractVersion(const std::string& text) {
+    for (size_t i = 0; i < text.size(); ++i) {
+        if (!std::isdigit(static_cast<unsigned char>(text[i]))) continue;
+        size_t end = i;
+        int dots = 0;
+        while (end < text.size()) {
+            if (std::isdigit(static_cast<unsigned char>(text[end]))) {
+                ++end;
+                continue;
+            }
+            if (text[end] == '.' && dots < 2 && end + 1 < text.size() &&
+                std::isdigit(static_cast<unsigned char>(text[end + 1]))) {
+                ++dots;
+                ++end;
+                continue;
+            }
+            break;
+        }
+        if (end > i) return text.substr(i, end - i);
+    }
+    return {};
+}
+
+bool parseVersionPart(const std::string& text, size_t& pos, uint64_t& out) {
+    if (pos >= text.size() || !std::isdigit(static_cast<unsigned char>(text[pos]))) return false;
+    uint64_t value = 0;
+    while (pos < text.size() && std::isdigit(static_cast<unsigned char>(text[pos]))) {
+        value = value * 10ULL + static_cast<uint64_t>(text[pos] - '0');
+        ++pos;
+    }
+    out = value;
+    return true;
+}
+
+int compareVersions(const std::string& left, const std::string& right) {
+    size_t lp = 0;
+    size_t rp = 0;
+    for (int part = 0; part < 3; ++part) {
+        uint64_t lv = 0;
+        uint64_t rv = 0;
+        if (!parseVersionPart(left, lp, lv) || !parseVersionPart(right, rp, rv)) return 0;
+        if (lv < rv) return -1;
+        if (lv > rv) return 1;
+        if (lp < left.size() && left[lp] == '.') ++lp;
+        if (rp < right.size() && right[rp] == '.') ++rp;
+    }
+    return 0;
+}
+
+} // namespace
+
+UpdateChecker::Result UpdateChecker::checkLatest(const std::string& currentVersion) {
+    Result result;
+    result.localVersion = extractVersion(currentVersion);
+    if (result.localVersion.empty()) {
+        result.error = "Invalid local application version";
+        diagnostics::log("[UpdateChecker] invalid local version: " + currentVersion);
+        return result;
+    }
+
+    HttpClient http;
+    if (http.init() != HttpResult::Ok) {
+        result.error = "Unable to initialize HTTP client";
+        diagnostics::log("[UpdateChecker] HTTP initialization failed");
+        return result;
+    }
+
+    std::string body;
+    const HttpResult fetchResult = http.fetchToString(RELEASES_LATEST_URL, body, 512 * 1024);
+    if (fetchResult != HttpResult::Ok) {
+        result.error = http.lastError().empty() ? toString(fetchResult) : http.lastError();
+        diagnostics::log("[UpdateChecker] GitHub request failed: " + result.error);
+        http.shutdown();
+        return result;
+    }
+
+    const int moduleResult = sceSysmoduleLoadModule(SCE_SYSMODULE_JSON);
+    if (moduleResult < 0) {
+        result.error = "Unable to load Vita JSON module";
+        diagnostics::log("[UpdateChecker] JSON module load failed");
+        http.shutdown();
+        return result;
+    }
+
+    VitaJsonAllocator allocator;
+    sce::Json::InitParameter params;
+    params.allocator = &allocator;
+    params.userData = nullptr;
+    params.bufSize = 64 * 1024;
+
+    sce::Json::Initializer initializer;
+    if (initializer.initialize(&params) < 0) {
+        result.error = "Unable to initialize Vita JSON parser";
+        diagnostics::log("[UpdateChecker] JSON initializer failed");
+        http.shutdown();
+        return result;
+    }
+
+    sce::Json::Value root;
+    if (sce::Json::Parser::parse(root, body.c_str()) < 0) {
+        result.error = "Invalid GitHub release JSON";
+        diagnostics::log("[UpdateChecker] GitHub release JSON parse failed");
+        initializer.terminate();
+        http.shutdown();
+        return result;
+    }
+
+    result.releaseTag = getString(root, "tag_name");
+    result.releaseName = getString(root, "name");
+
+    const bool conventionalTag = !result.releaseTag.empty() &&
+        (std::isdigit(static_cast<unsigned char>(result.releaseTag[0])) ||
+         result.releaseTag[0] == 'v' || result.releaseTag[0] == 'V');
+    if (conventionalTag) result.remoteVersion = extractVersion(result.releaseTag);
+    if (result.remoteVersion.empty()) result.remoteVersion = extractVersion(result.releaseName);
+    if (result.remoteVersion.empty()) result.remoteVersion = extractVersion(result.releaseTag);
+
+    const sce::Json::Value& assetsValue = root["assets"];
+    if (assetsValue) {
+        const sce::Json::Array& assets = assetsValue.getArray();
+        for (SceSize i = 0; i < assets.size(); ++i) {
+            const sce::Json::Value& asset = assetsValue[i];
+            const std::string name = getString(asset, "name");
+            if (name != UPDATE_ASSET_NAME) continue;
+            result.assetName = name;
+            result.downloadUrl = getString(asset, "browser_download_url");
+            result.digest = getString(asset, "digest");
+            result.assetSize = getUnsigned(asset, "size");
+            break;
+        }
+    }
+
+    if (result.remoteVersion.empty()) {
+        result.error = "GitHub release does not expose a usable version";
+    } else if (result.downloadUrl.empty()) {
+        result.error = "GitHub release does not contain PSVitaAlive.vpk";
+    } else if (compareVersions(result.localVersion, result.remoteVersion) < 0) {
+        result.state = State::UpdateAvailable;
+        diagnostics::log("[UpdateChecker] update available: local=" + result.localVersion +
+                         " remote=" + result.remoteVersion + " asset=" + result.assetName);
+    } else {
+        result.state = State::UpToDate;
+        diagnostics::log("[UpdateChecker] client is up to date: " + result.localVersion +
+                         " remote=" + result.remoteVersion);
+    }
+
+    if (result.state == State::Failed) {
+        diagnostics::log("[UpdateChecker] check failed: " + result.error);
+    }
+
+    initializer.terminate();
+    http.shutdown();
+    return result;
+}
+
+} // namespace psvitaalive


### PR DESCRIPTION
## Phase 1 — update checker

Implements the first, read-only phase of the PSVitaAlive self-update system.

### What changed
- Adds `UpdateChecker` using GitHub `releases/latest`.
- Reads the release version and locates the `PSVitaAlive.vpk` asset.
- Supports the current release naming (`BETA-0.1` tag + `BETA 01.00` release name).
- Exposes `VITA_VERSION` to C++ from the existing CMake version source.
- Runs the check inside the existing CatalogManager worker before the first catalog request, so the existing loading screen is reused and `main.cpp` does not need a risky startup rewrite.
- If the check fails, catalog startup continues normally.
- If an update is detected, it is logged/displayed for this phase; installation is intentionally not implemented yet.

### Next phase
After this branch is validated on Vita3K/PS Vita, add the self-update installer: download/verify VPK, validate Title ID, replace `ux0:app/PSVAS1178`, and relaunch the app.