### PR TITLE
Apply PSVitaAlive client Title ID update

### DIFF
--- a/.github/workflows/title-id-update-pr.yml
+++ b/.github/workflows/title-id-update-pr.yml
@@ -1,0 +1,63 @@
+name: Apply PSVitaAlive client Title ID update
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+
+jobs:
+  apply-on-main:
+    if: github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Replace and validate client Title ID
+        shell: bash
+        run: |
+          set -euo pipefail
+          OLD='PSVA00001'
+          NEW='PSVAS1178'
+          CLIENT='Client PSVitaAlive'
+
+          mapfile -t files < <(git grep -l "$OLD" -- "$CLIENT" || true)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo 'ERROR: old Title ID not found in the client.' >&2
+            exit 1
+          fi
+
+          for file in "${files[@]}"; do
+            case "$file" in
+              "$CLIENT/CMakeLists.txt"|"$CLIENT/README.md"|"$CLIENT/SETUP_COPIAR.md"|"$CLIENT/source/main.cpp")
+                sed -i "s/$OLD/$NEW/g" "$file"
+                ;;
+              *)
+                echo "ERROR: unexpected client file containing old Title ID: $file" >&2
+                exit 1
+                ;;
+            esac
+          done
+
+          if git grep -n "$OLD" -- "$CLIENT"; then
+            echo 'ERROR: old Title ID remains.' >&2
+            exit 1
+          fi
+          git diff --check
+          git diff -- "$CLIENT/CMakeLists.txt" "$CLIENT/README.md" "$CLIENT/SETUP_COPIAR.md" "$CLIENT/source/main.cpp"
+
+      - name: Commit to main and remove temporary workflows
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git rm -f .github/workflows/title-id-update-pr.yml .github/workflows/update-client-title-id.yml || true
+          git add -- "Client PSVitaAlive/CMakeLists.txt" "Client PSVitaAlive/README.md" "Client PSVitaAlive/SETUP_COPIAR.md" "Client PSVitaAlive/source/main.cpp"
+          git commit -m 'Update client Title ID to PSVAS1178'
+          git push origin main


### PR DESCRIPTION
Controlled update to replace the confirmed old client Title ID `PSVA00001` with `PSVAS1178` in the client, validate the resulting diff, and remove the temporary workflow files.